### PR TITLE
Don't just silently exit on an unexpected answer to Yes/No question.

### DIFF
--- a/android-backup
+++ b/android-backup
@@ -298,7 +298,7 @@ main() {
     case $yn in
       'Yes'* ) ;;  # just get through
       'No'* ) exit;;
-      * ) exit 2;;
+      * ) echo_error "Unexpected answer: '$yn' Quitting..."; exit 2;;
     esac
   fi
 

--- a/android-restore
+++ b/android-restore
@@ -308,7 +308,7 @@ main() {
     case $yn in
       'Yes'* ) ;;  # just get through
       'No'* ) exit;;
-      * ) exit 3;;
+      * ) echo_error "Unexpected answer: '$yn' Quitting..."; exit 3;;
     esac
   fi
 


### PR DESCRIPTION
Usually cli programs don't care about the case of the answer to a yes/no question.
I was surprised/didn't know what happened, when I answered `yes` and the program silently exited.
I was wondering, if that's a bug.
As I don't know, whether you intentionally want to check for the case, I just added an error message.