### PR TITLE
remove unused function.

### DIFF
--- a/android-backup
+++ b/android-backup
@@ -64,9 +64,6 @@ adb_pull_app() {
 adb_push() {
   ${ADB} push -p "$1" "$2"
 }
-adb_rm_dir() {
-  ${ADB} shell "[[ -d \"$1\" ]] && rm -r \"$1\""
-}
 rsync_cleanup_local() {
   echo_debug "Removing local rsync filter file ..."
   [[ -e "${LOCAL_RSYNC_FILTER_FILE}" ]] && rm "${LOCAL_RSYNC_FILTER_FILE}"


### PR DESCRIPTION
This function is never called.

For the record, I believe (but didn't test) it is vulnerable to command injection.

For example a file named something like `file" ]] ; evilcommand #` would result in the adb shell seeing

"[[ -d "file" ]] ; evilcommand #" ]] && rm -r "file" ]] ; evilcommand #"

It's a good thing this function is not used anymore. Doesn't android provide the `rmdir` command?

In the future an escaping mechanism like ${1@Q} might be the correct way.